### PR TITLE
Replace deprecated mpl.cm.get_cmap() with mpl.colormaps[]

### DIFF
--- a/src/scimilarity/visualizations.py
+++ b/src/scimilarity/visualizations.py
@@ -299,7 +299,7 @@ def draw_circles(
 
     fig, ax = plt.subplots(figsize=figsize)
     if use_colormap:
-        cmap = mpl.cm.get_cmap(use_colormap)
+        cmap = mpl.colormaps[use_colormap]
 
     ax.set_title(title)  # title
     ax.axis("off")  # remove axes


### PR DESCRIPTION
`mpl.cm.get_cmap()` was deprecated in matplotlib 3.7 and removed in 3.9. This replaces the single call in `visualizations.py` with `mpl.colormaps[]`.