### PR TITLE
Replace bare except clauses with specific exception types

### DIFF
--- a/src/scimilarity/cell_annotation.py
+++ b/src/scimilarity/cell_annotation.py
@@ -89,7 +89,7 @@ class CellAnnotation(CellSearchKNN):
         for i in self.idx2label:
             try:  # throws an expection if not already marked
                 self.knn.unmark_deleted(i)
-            except:
+            except RuntimeError:
                 pass
 
     def blocklist_celltypes(self, labels: Union[List[str], Set[str]]):
@@ -142,7 +142,7 @@ class CellAnnotation(CellSearchKNN):
         for i in self.idx2label:  # mark all
             try:  # throws an exception if already marked
                 self.knn.mark_deleted(i)
-            except:
+            except RuntimeError:
                 pass
         for i, celltype_name in self.idx2label.items():
             if celltype_name in self.safelist:

--- a/src/scimilarity/tiledb_data_models.py
+++ b/src/scimilarity/tiledb_data_models.py
@@ -431,9 +431,8 @@ class CellMultisetDataModule(pl.LightningDataModule):
             for x in self.gene_order:
                 try:
                     self.gene_indices.append(genes.index(x))
-                except:
+                except ValueError:
                     log.info(f"Gene not found: {x}")
-                    pass
         else:
             self.gene_order = genes
             self.gene_indices = list(range(len(genes)))


### PR DESCRIPTION
## Description

Replaces three bare `except:` clauses with specific exception types to avoid silently catching `KeyboardInterrupt`, `SystemExit`, and other critical exceptions.

### Changes

- `cell_annotation.py` L92: `except:` → `except RuntimeError:` (hnswlib `unmark_deleted` raises `RuntimeError` for unmarked elements)
- `cell_annotation.py` L145: `except:` → `except RuntimeError:` (hnswlib `mark_deleted` raises `RuntimeError` for already-marked elements)
- `tiledb_data_models.py` L434: `except:` → `except ValueError:` (`list.index()` raises `ValueError` when element is not found)

Skipped the bare except in `setup.py` (intentional fallback pattern, already has `# noqa`).